### PR TITLE
Provide meta/run.yaml and README.md for OpenFOAM packages

### DIFF
--- a/docker_files/recipes/openfoam.core/meta/README.md
+++ b/docker_files/recipes/openfoam.core/meta/README.md
@@ -1,0 +1,11 @@
+# OpenFOAM Core 2.4.0
+This package provides core libraries, binaries and default configuration required
+by the OpenFOAM solvers.
+
+## Usage
+You only need to require this package and the libraries become available.
+In fact, the openfoam.core package is included in solvers so you shouldn't
+need to require this package manually.
+
+Note that configuration files reside inside /openfoam directory so solvers will need
+to set WM_PROJECT_DIR=/openfoam environment variable.

--- a/docker_files/recipes/openfoam.pimplefoam/meta/README.md
+++ b/docker_files/recipes/openfoam.pimplefoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM pimpleFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot pimpleFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.pimplefoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.pimplefoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  pimpleFoam:
+    bootcmd: /usr/bin/pimpleFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: pimpleFoam

--- a/docker_files/recipes/openfoam.pisofoam/meta/README.md
+++ b/docker_files/recipes/openfoam.pisofoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM pisoFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot pisoFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.pisofoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.pisofoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  pisoFoam:
+    bootcmd: /usr/bin/pisoFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: pisoFoam

--- a/docker_files/recipes/openfoam.poroussimplefoam/meta/README.md
+++ b/docker_files/recipes/openfoam.poroussimplefoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM porousSimpleFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot porousSimpleFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.poroussimplefoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.poroussimplefoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  porousSimpleFoam:
+    bootcmd: /usr/bin/porousSimpleFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: porousSimpleFoam

--- a/docker_files/recipes/openfoam.potentialfoam/meta/README.md
+++ b/docker_files/recipes/openfoam.potentialfoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM potentialFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot potentialFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.potentialfoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.potentialfoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  potentialFoam:
+    bootcmd: /usr/bin/potentialFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: potentialFoam

--- a/docker_files/recipes/openfoam.rhoporoussimplefoam/meta/README.md
+++ b/docker_files/recipes/openfoam.rhoporoussimplefoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM rhoPoroussSimpleFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot rhoPoroussSimpleFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.rhoporoussimplefoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.rhoporoussimplefoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  rhoPoroussSimpleFoam:
+    bootcmd: /usr/bin/rhoPoroussSimpleFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: rhoPoroussSimpleFoam

--- a/docker_files/recipes/openfoam.rhosimplefoam/meta/README.md
+++ b/docker_files/recipes/openfoam.rhosimplefoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM rhoSimpleFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot rhoSimpleFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.rhosimplefoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.rhosimplefoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  rhoSimpleFoam:
+    bootcmd: /usr/bin/rhoSimpleFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: rhoSimpleFoam

--- a/docker_files/recipes/openfoam.simplefoam/meta/README.md
+++ b/docker_files/recipes/openfoam.simplefoam/meta/README.md
@@ -1,0 +1,13 @@
+# OpenFOAM simpleFoam solver
+This package provides a solver provided by OpenFOAM.
+
+## Usage
+To run the solver on a provided OpenFOAM case, you should compose the unikernel with the case.
+```
+$ capstan run demo --boot simpleFoam --env FOAM_CASE_DIR=/case
+```
+| ENV            |  MAPS TO | DEFAULT VALUE  | EFFECT
+|----------------|----------|----------------|--------
+| FOAM_CASE_DIR  | -case    | /case          | location of your OpenFOAM case
+| FOAM_ARGS      | arg      | (empty)        | additional arguments
+| WM_PROJECT_DIR | env      | /openfoam      | location of core FOAM libraries

--- a/docker_files/recipes/openfoam.simplefoam/meta/run.yaml
+++ b/docker_files/recipes/openfoam.simplefoam/meta/run.yaml
@@ -1,0 +1,9 @@
+runtime: native
+config_set:
+  simpleFoam:
+    bootcmd: /usr/bin/simpleFoam.so -case $FOAM_CASE_DIR $FOAM_ARGS
+    env:
+      WM_PROJECT_DIR: /openfoam
+      FOAM_CASE_DIR: /case
+      FOAM_ARGS:
+config_set_default: simpleFoam


### PR DESCRIPTION
With this commit we first provide README for openfoam.core package and then meta/run.yaml and README for each openfoam solver package.