### PR TITLE
Escape `'` and `?` for test expectations

### DIFF
--- a/docker_files/capstan-packages.py
+++ b/docker_files/capstan-packages.py
@@ -523,6 +523,8 @@ def test_recipe(recipe):
     expected = expected.replace('(', '\(').replace(')', '\)')
     expected = expected.replace('[', '\[').replace(']', '\]')
     expected = expected.replace('"', '\"')
+    expected = expected.replace("'", "\'")
+    expected = expected.replace("?", "\?")
     is_ok = re.search(expected, output) is not None
 
     if not is_ok:


### PR DESCRIPTION
The Python package uses these two chars in the expectation file causing it to
fail with the current escape rules. This commit replaces every occurrence of
these two chars with `\'` and `\?`.
