### PR TITLE
Fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ BSD license:
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
 
-    * Neither the name of the Cloudius Systems, Ltd. nor the names of its
+    * Neither the name of the XLAB, Ltd. nor the names of its
       contributors may be used to endorse or promote products derived from this
       software without specific prior written permission.
 


### PR DESCRIPTION
When copying LICENSE text from the Capstan repository we somehow overlooked that we didn't insert the name of our company everywhere. With this commit we do it properly.