### PR TITLE
Introduce osv.compose-remote-base and osv.compose-remote

### DIFF
--- a/docker_files/recipes/osv.compose-remote-base/build.sh
+++ b/docker_files/recipes/osv.compose-remote-base/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cd ${PACKAGE_RESULT_DIR}
+capstan package init --name "${PACKAGE_NAME}" \
+    --title "compose-remote util for preparing base image" \
+    --author "MIKELANGELO Project (info@mikelangelo-project.eu)" \
+    --version 0.1 \
+    --platform ${PLATFORM}

--- a/docker_files/recipes/osv.compose-remote-base/demo/expected-stdout.txt
+++ b/docker_files/recipes/osv.compose-remote-base/demo/expected-stdout.txt
@@ -1,0 +1,1 @@
+Finished uploading files. Please reboot unikernel to run application.

--- a/docker_files/recipes/osv.compose-remote-base/demo/pkg/meta/package.yaml.templ
+++ b/docker_files/recipes/osv.compose-remote-base/demo/pkg/meta/package.yaml.templ
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+name: demo
+title: demo
+author: MIKELANGELO Project (info@mikelangelo-project.eu)
+version: "0.1"
+require:
+  - ${PACKAGE_NAME}

--- a/docker_files/recipes/osv.compose-remote-base/demo/pkg/meta/run.yaml
+++ b/docker_files/recipes/osv.compose-remote-base/demo/pkg/meta/run.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+runtime: native
+
+config_set:
+  default:
+    base: "osv.compose-remote-base:app"
+
+config_set_default: default

--- a/docker_files/recipes/osv.compose-remote-base/meta/README.md
+++ b/docker_files/recipes/osv.compose-remote-base/meta/README.md
@@ -1,0 +1,17 @@
+# Remote Compose package for creating base
+This package provides nothing but an 'init' run configuration
+that gets stored into /run/init file. When run, it starts cpiod
+tool on port 10000 and is ready to upload files.
+
+## Usage
+Require this package when you're preparing base image for your
+cloud provider. Set bootcmd like this:
+
+```
+$ capstan package compose base --run "runscript /run/init;runscript /run/app"
+```
+
+When instance will be started out of such image, it will run the cpiod
+tool and wait for you to upload files using `capstan package compose-remote`.
+See also osv.compose-remote package that is automatically required by
+compose-remote command.

--- a/docker_files/recipes/osv.compose-remote-base/meta/run.yaml
+++ b/docker_files/recipes/osv.compose-remote-base/meta/run.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+runtime: native
+config_set:
+  init:
+    bootcmd: /tools/cpiod.so --prefix /
+  app:
+    bootcmd: /bin/echo.so \nFinished uploading files. Please reboot unikernel to run application.

--- a/docker_files/recipes/osv.compose-remote/build.sh
+++ b/docker_files/recipes/osv.compose-remote/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+cd ${PACKAGE_RESULT_DIR}
+capstan package init --name "${PACKAGE_NAME}" \
+    --title "compose-remote util for contextualizing instance" \
+    --author "MIKELANGELO Project (info@mikelangelo-project.eu)" \
+    --version 0.1 \
+    --platform ${PLATFORM}

--- a/docker_files/recipes/osv.compose-remote/demo/expected-stdout.txt
+++ b/docker_files/recipes/osv.compose-remote/demo/expected-stdout.txt
@@ -1,0 +1,1 @@
+Skip init.

--- a/docker_files/recipes/osv.compose-remote/demo/pkg/meta/package.yaml.templ
+++ b/docker_files/recipes/osv.compose-remote/demo/pkg/meta/package.yaml.templ
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+name: demo
+title: demo
+author: MIKELANGELO Project (info@mikelangelo-project.eu)
+version: "0.1"
+require:
+  - ${PACKAGE_NAME}

--- a/docker_files/recipes/osv.compose-remote/demo/pkg/meta/run.yaml
+++ b/docker_files/recipes/osv.compose-remote/demo/pkg/meta/run.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+runtime: native
+
+config_set:
+  default:
+    base: "osv.compose-remote:init"
+
+config_set_default: default

--- a/docker_files/recipes/osv.compose-remote/meta/README.md
+++ b/docker_files/recipes/osv.compose-remote/meta/README.md
@@ -1,0 +1,20 @@
+# Remote Compose package for contextualizing remote instance
+This package provides nothing but an 'init' run configuration
+that gets stored into /run/init file. When run, it sleeps for 0
+seconds, effectively doing nothing.
+
+This package is required automatically by `capstan package compose-remote` command
+so you shouldn't need to require it manually. The purpose of the package is to
+neutralize the osv.compose-remote-base package once the unikernel is contextualized
+i.e. when the files are uploaded.
+
+## Usage
+Just bear in mind that remote instance has following bootcmd set:
+
+```
+runscript /run/init;runscript /run/app
+```
+
+The first part of the command (`runscript /run/init`) will return immediately resulting in
+`runscript /run/app` acting like the only bootcmd. So in your current package you need to make
+sure that you provide run configuration named "app" in order for it to get booted in the instance.

--- a/docker_files/recipes/osv.compose-remote/meta/run.yaml
+++ b/docker_files/recipes/osv.compose-remote/meta/run.yaml
@@ -1,0 +1,11 @@
+#
+# Copyright (C) 2017 XLAB, Ltd.
+#
+# This work is open source software, licensed under the terms of the
+# BSD license as described in the LICENSE file in the top-level directory.
+#
+
+runtime: native
+config_set:
+  init:
+    bootcmd: /bin/echo.so \nSkip init.


### PR DESCRIPTION
With this commit we introduce two auxilary packages that are used by Capstan to support `capstan package compose-remote` command:

```
- osv.compose-remote-base # needed when preparing the image
- osv.compose-remote      # needed when contextualizing instance
```

When composing OSv image that will serve as base for actual instances (think AMI image or Glance image) user must manually require the osv.compose-remote-base package and set bootcmd like this:

```
$ capstan package compose base --run "runscript /run/init; runscript /run/app"
```

Then she uploads the result to the cloud provider. Whenever a new instance will be run out of it, the cpiod will be started on port 10000 waiting for someone to connect. At that time, user can contextualize her unikernel like this:

```
$ capstan package compose-remote <unikernel-IP-or-hostname>
```

The compose-remote command will automatically require osv.compose-remote package that replaces the /run/init cpiod command with dummy command that just exits immediately.

Related to: https://groups.google.com/forum/#!topic/osv-dev/ha_ouYegYAc

/cc @wkozaczuk